### PR TITLE
Add support for Ubuntu 18.10, 19.04 and 19.10

### DIFF
--- a/swiftbox.sh
+++ b/swiftbox.sh
@@ -3,6 +3,10 @@
 if [ "E`lsb_release -i --short`" = "EUbuntu" ]
 then
     UBUNTU_VERSION=`lsb_release -r --short`
+    if [ ${UBUNTU_VERSION//./} -gt 1804 ] && [ ${UBUNTU_VERSION//./} -lt 2004 ]
+    then
+      UBUNTU_VERSION="18.04"
+    fi
 else
     echo "This program only support Ubuntu. "
     exit 255


### PR DESCRIPTION
Swift (only tested 5.2) works perfectly on Ubuntu 18.10, 19.04 and 19.10 but there is no swift releases which contains these Ubuntu versions in their names.

So a small change to add a support for these Ubuntu versions.